### PR TITLE
fix(security): disable doas

### DIFF
--- a/modules/nixos/suites/common-slim/default.nix
+++ b/modules/nixos/suites/common-slim/default.nix
@@ -33,7 +33,7 @@ in
       };
 
       security = {
-        doas = enabled;
+        doas = disabled;
       };
 
       services = {

--- a/modules/nixos/suites/common/default.nix
+++ b/modules/nixos/suites/common/default.nix
@@ -38,7 +38,7 @@ in
 
       security = {
         gpg = enabled;
-        doas = enabled;
+        doas = disabled;
         keyring = enabled;
       };
 

--- a/systems/x86_64-do/base/default.nix
+++ b/systems/x86_64-do/base/default.nix
@@ -28,7 +28,7 @@ with lib.dafos;
     };
 
     security = {
-      doas = enabled;
+      doas = disabled;
     };
 
     services = {

--- a/systems/x86_64-install-iso/graphical/default.nix
+++ b/systems/x86_64-install-iso/graphical/default.nix
@@ -55,7 +55,7 @@ with lib.dafos;
     };
 
     security = {
-      doas = enabled;
+      doas = disabled;
       keyring = enabled;
     };
 

--- a/systems/x86_64-install-iso/minimal/default.nix
+++ b/systems/x86_64-install-iso/minimal/default.nix
@@ -34,7 +34,7 @@ with lib.dafos;
     };
 
     security = {
-      doas = enabled;
+      doas = disabled;
     };
 
     system = {

--- a/systems/x86_64-iso/isolated/default.nix
+++ b/systems/x86_64-iso/isolated/default.nix
@@ -68,7 +68,7 @@ in
       };
     };
 
-    security = { doas = enabled; };
+    security = { doas = disabled; };
 
     system = {
       fonts = enabled;

--- a/systems/x86_64-iso/rescue/default.nix
+++ b/systems/x86_64-iso/rescue/default.nix
@@ -16,7 +16,7 @@ with lib.dafos;
 
     hardware = { networking = enabled; };
 
-    security = { doas = enabled; };
+    security = { doas = disabled; };
 
     system = {
       fonts = enabled;

--- a/systems/x86_64-virtualbox/virt/default.nix
+++ b/systems/x86_64-virtualbox/virt/default.nix
@@ -53,7 +53,7 @@ with lib.dafos;
     services = { printing = enabled; };
 
     security = {
-      doas = enabled;
+      doas = disabled;
       keyring = enabled;
     };
 


### PR DESCRIPTION
this might cause issues when programs automatically invoke sudo (which isn't found).

Fix an issue with `nh` where it could not find `sudo` and thus is unable to switch to the newly built generation.