### PR TITLE
fix(logiops): service needs restart on boot

### DIFF
--- a/modules/nixos/services/logiops/README.org
+++ b/modules/nixos/services/logiops/README.org
@@ -3,12 +3,3 @@
 * Known Issues
 ** ~logiops~ is out of date
 Current ~nixpkgs~ version is 0.2.3, while upstream is 0.3.3
-
-** service needs to be restarted on boot
-
-The service probably starts too soon, but I haven't been able to fix it.
-For now run:
-
-#+begin_src bash
-sudo systemctl restart logid.service
-#+end_src

--- a/modules/nixos/services/logiops/default.nix
+++ b/modules/nixos/services/logiops/default.nix
@@ -23,10 +23,15 @@ in
       enable = true;
       description = "Logitech Configuration Daemon.";
       wantedBy = [ "graphical.target" ];
+      after = [ "multi-user.target" ];
+      wants = [ "multi-user.target" ];
+      startLimitIntervalSec = 0;
       serviceConfig = {
         Type = "simple";
-        Restart = "on-failure";
+        ExecStartPre = "${pkgs.kmod}/bin/modprobe hid_logitech_hidpp || :";
         ExecStart = "${pkgs.logiops}/bin/logid -c " + ./logid.cfg;
+        ExecReload = "/bin/kill -HUP $MAINPID";
+        Restart = "on-failure";
       };
     };
   };


### PR DESCRIPTION
booting up the system resulted in logiops starting correctly but the configuration wasn't taken into account.