### PR TITLE
kanata: switch from custom bépo config to arsenik with Ergo-L

### DIFF
--- a/modules/nixos/system/kanata/defalias/azerty_pc.kbd
+++ b/modules/nixos/system/kanata/defalias/azerty_pc.kbd
@@ -1,0 +1,88 @@
+;; Azerty Windows/Linux aliases
+;; Works with AZERTY-fr. Needs a couple tweaks for the Belgian and Mac variants.
+
+;; Navigation layer
+(defalias
+
+  all C-q
+  sav C-s
+  cls C-z
+  ndo C-w
+  cut C-x
+  cpy C-c
+  pst C-v
+
+  0 S-0
+  1 S-1
+  2 S-2
+  3 S-3
+  4 S-4
+  5 S-5
+  6 S-6
+  7 S-7
+  8 S-8
+  9 S-9
+  , m
+  . S-,
+)
+
+;; Symbols layer
+(defalias
+
+  ^  (macro [ spc)
+  <  <
+  >  S-<
+  $  ]
+  %  S-'
+  @  AG-0
+  &  1
+  *  \
+  '  4
+  `  (macro AG-7 spc)
+
+  {  AG-4
+  pl 5
+  pr -
+  }  AG-=
+  =  =
+  \  AG-8
+  +  S-=
+  -  6
+  /  S-.
+  '' 3
+
+  ~  (macro AG-2 spc)
+  [  AG-5
+  ]  AG--
+  _  8
+  #  AG-3
+  |  AG-6
+  !  /
+  ;  ,
+  :  .
+  ?  S-m
+)
+
+;; NumRow layer
+(defalias
+
+  s0 0
+  s1 1
+  s2 2
+  s3 3
+  s4 4
+  s5 5
+  s6 6
+  s7 7
+  s8 8
+  s9 9
+  nbs (unicode  ) ;; narrow non-break space
+
+  dk1 XX
+  dk2 XX
+  dk3 XX
+  dk4 XX
+  dk5 XX
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defalias/bepo_pc.kbd
+++ b/modules/nixos/system/kanata/defalias/bepo_pc.kbd
@@ -1,0 +1,87 @@
+;; Bépo Windows/Linux aliases
+
+;; Navigation layer
+(defalias
+
+  all C-a
+  sav C-k
+  cls C-]
+  ndo C-[
+  cut C-c
+  cpy C-h
+  pst C-u
+
+  0 S-0
+  1 S-1
+  2 S-2
+  3 S-3
+  4 S-4
+  5 S-5
+  6 S-6
+  7 S-7
+  8 S-8
+  9 S-9
+  , g
+  . v
+)
+
+;; Symbols layer
+(defalias
+
+  ^  AG-6
+  <  AG-2
+  >  AG-3
+  $  `
+  %  =
+  @  6
+  &  AG-e
+  *  0
+  '  AG-g
+  `  S-=
+
+  {  AG-x
+  pl 4
+  pr 5
+  }  AG-c
+  =  -
+  \  AG-z
+  +  7
+  -  8
+  /  AG-<
+  '' 1
+
+  ~  AG-b
+  [  AG-4
+  ]  AG-5
+  _  AG-spc
+  #  S-`
+  |  AG-q
+  !  S-y
+  ;  S-g
+  :  S-v
+  ?  S-n
+)
+
+;; NumRow layer
+(defalias
+
+  s0 0
+  s1 1
+  s2 2
+  s3 3
+  s4 4
+  s5 5
+  s6 6
+  s7 7
+  s8 8
+  s9 9
+  nbs S-spc ;; narrow no-break space
+
+  dk1 XX
+  dk2 XX
+  dk3 XX
+  dk4 XX
+  dk5 XX
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defalias/ergol_pc.kbd
+++ b/modules/nixos/system/kanata/defalias/ergol_pc.kbd
@@ -1,0 +1,89 @@
+;; Ergo‑L Windows/Linux aliases
+
+;; Navigation layer
+(defalias
+
+  all C-a
+  sav C-s
+  cls C-t
+  ndo C-z
+  cut C-x
+  cpy C-w
+  pst C-v
+
+  0 0
+  1 1
+  2 2
+  3 3
+  4 4
+  5 5
+  6 6
+  7 7
+  8 8
+  9 9
+  , .
+  . n
+)
+
+;; Symbols layer
+(defalias
+
+  ^  AG-q
+  <  AG-w
+  >  AG-e
+  $  AG-r
+  %  AG-t
+  @  AG-y
+  &  AG-u
+  *  AG-i
+  '  AG-o
+  `  AG-p
+
+  {  AG-a
+  pl AG-s
+  pr AG-d
+  }  AG-f
+  =  AG-g
+  \  AG-h
+  +  AG-j
+  -  AG-k
+  /  AG-l
+  '' AG-;
+
+  ~  AG-z
+  [  AG-x
+  ]  AG-c
+  _  AG-v
+  #  AG-b
+  |  AG-n
+  !  AG-m
+  ;  AG-,
+  :  AG-.
+  ?  AG-/
+)
+
+;; NumRow layer
+(defalias
+
+  s0 S-0
+  s1 S-1
+  s2 S-2
+  s3 S-3
+  s4 S-4
+  s5 S-5
+  s6 S-6
+  s7 S-7
+  s8 S-8
+  s9 S-9
+  nbs S-spc ;; narrow no-break space
+
+  1dk o
+  ;; digits must be escaped, otherwise they’re interpreted as delays in ms
+  dk1 (macro @1dk @1)
+  dk2 (macro @1dk @2)
+  dk3 (macro @1dk @3)
+  dk4 (macro @1dk @4)
+  dk5 (macro @1dk @5)
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/default.nix
+++ b/modules/nixos/system/kanata/default.nix
@@ -18,6 +18,14 @@ let
   inherit (lib.${namespace}) mkOpt mkBoolOpt;
 
   cfg = config.${namespace}.system.kanata;
+
+  readPart = path: builtins.readFile (./. + "/${path}");
+
+  defsrcFile = "defsrc/pc_anglemod.kbd";
+  baseFile = "deflayer/base_lt_hrm.kbd";
+  symbolsFile = "deflayer/symbols_noop_num.kbd";
+  navigationFile = "deflayer/navigation_vim.kbd";
+  layoutAliasFile = "defalias/ergol_pc.kbd";
 in
 {
   options.${namespace}.system.kanata = {
@@ -31,9 +39,9 @@ in
       "Espanso virtual device"
       "WH-1000XM3 (AVRCP)"
     ] "The devices to be excluded.";
-    tapTimeout = mkOpt types.number 150 "The value for tap-timeout.";
-    holdTimeout = mkOpt types.number 300 "The value for hold-timeout.";
-    chordTimeout = mkOpt types.number 10 "The value for chord-timeout.";
+    tapTimeout = mkOpt types.number 200 "Arsenik tap_timeout: key must be pressed twice within this many ms to enable repetitions.";
+    holdTimeout = mkOpt types.number 200 "Arsenik hold_timeout: key must be held this many ms to become a layer shift.";
+    longHoldTimeout = mkOpt types.number 300 "Arsenik long_hold_timeout: slightly higher value for typing keys, to prevent unexpected hold effect.";
   };
 
   config = mkIf cfg.enable {
@@ -43,7 +51,7 @@ in
     services.kanata = {
       enable = true;
 
-      keyboards."bepo" =
+      keyboards."ergol" =
         let
           mkExcludedDevices =
             devices:
@@ -59,229 +67,33 @@ in
           extraDefCfg = ''
             ${mkExcludedDevices cfg.excludedDevices}
             linux-device-detect-mode keyboard-only
+            process-unmapped-keys yes
           '';
           config = ''
+            ;; Timing variables for tap-hold effects.
             (defvar
-              tap-timeout   ${toString cfg.tapTimeout}
-              hold-timeout  ${toString cfg.holdTimeout}
-              chord-timeout ${toString cfg.chordTimeout}
-              tt $tap-timeout
-              ht $hold-timeout
-              ct $chord-timeout
+              tap_timeout       ${toString cfg.tapTimeout}
+              hold_timeout      ${toString cfg.holdTimeout}
+              long_hold_timeout ${toString cfg.longHoldTimeout}
             )
 
-            (deflocalkeys-linux
-              '<   86
-              'w   27
-              'z   26
-              'y   45
-              à    44
-              è    20
-            )
+            ;; -- defsrc --
+            ${readPart defsrcFile}
 
-            (defsrc
-              esc     f1   f2   f3   f4   f5   f6   f7   f8   f9   f10  f11  f12  del
-              grv     1    2    3    4    5    6    7    8    9    0    -    =    bspc
-              tab     q    w    e    r    t    y    u    i    o    p    [    ]
-              caps    a    s    d    f    g    h    j    k    l    ;    '    ret
-              lsft    '<   z    x    c    v    b    n    m    ,    .    /    rsft
-              lctl lmet lalt              spc            ralt rctl
-            )
+            ;; -- base layer --
+            ${readPart baseFile}
 
-            (defalias
-              ;; toggle layer aliases
-              ars   (layer-while-held arrows-symbols)
-              med   (layer-while-held media-controls)
-              num   (layer-while-held numbers)
-              gam   (layer-switch gaming)
-              qwe   (layer-switch qwerty)
-              lsw   (layer-while-held layers-switcher)
-              dft   (layer-switch bépow)
-              bas   (layer-switch basic)
+            ;; -- symbols layer --
+            ${readPart symbolsFile}
 
-              ;; tap within $tt for esc, hold more than $ht for lctl
-              cap      (tap-hold $tt $ht esc lctl)
-              rbspc    (tap-hold-release $tt $ht up bspc)
+            ;; -- navigation layer --
+            ${readPart navigationFile}
 
-              ;; home row mode
-              lMe      (tap-hold-release $tt $ht f lmet)   ;; e → meta
-              lCi      (tap-hold-release $tt $ht d lctrl)  ;; i → ctrl
-              numa     (tap-hold-release $tt $ht a @num)   ;; a → numbers
-              ars;     (tap-hold-release $tt $ht ; @ars)   ;; n → arrows-symbols
+            ;; -- layout aliases (Ergo-L PC) --
+            ${readPart layoutAliasFile}
 
-              mc=      (tap-hold-release $tt $ht min @med) ;; = → media-controls
-
-              rSspc    (tap-hold-release $tt $ht spc rsft)  ;; spc → shift
-              <ars     (tap-hold-release $tt $ht RA-à @ars) ;; à → arrows-symbols
-              rAbspc   (tap-hold-release $tt $ht bspc ralt) ;; bspc → alt
-              grv      (tap-hold-release $tt $ht (tap-dance $tt (grv @dft)) @lsw)
-
-              ;; chords
-              cht (chord chords j) ;; t
-              chs (chord chords k) ;; s
-              chq (chord chords m) ;; q
-              chg (chord chords ,) ;; g
-            )
-
-            (defalias
-              [     AG-4
-              ]     AG-5
-              {     AG-x
-              }     AG-c
-              ^     AG-6
-              'lp   4
-              'rp   5
-              at    6
-              +     7
-              -     8
-              /     9
-              *     0
-              <     AG-2
-              >     AG-3
-              |     AG-q
-              \     AG-à
-              ~     AG-b
-              _     AG-spc
-              `     AG-S-è
-              $     `
-              =     -
-              %     =
-              :     S-v
-            )
-
-            (defalias
-              '1  kp1
-              '2  kp2
-              '3  kp3
-              '4  kp4
-              '5  kp5
-              '6  kp6
-              '7  kp7
-              '8  kp8
-              '9  kp9
-              '0  kp0
-            )
-
-            (defchords chords $chord-timeout
-              (j  ) j
-              (k  ) k
-              (j k) C-bspc
-              (m  ) m
-              (,  ) ,
-              (m ,) tab
-            )
-
-            (deflayer bépow
-              _     _     _     _     _     _     _     _     _     _     _     _     _    _
-              @grv  _     _     _     _     _     _     _     _     _     _     @mc=  _    _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              @cap  @numa _     @lCi  @lMe  _     _     @cht  @chs  _     @ars; _     _
-              _     @<ars _     _     _     _     _     _     @chq  @chg  _     _     @rbspc
-              _     _     _                   @rSspc               @rAbspc  _
-            )
-
-            (deflayer layers-switcher
-              _     _     _     _     _     _     _     _     _     _     _     _     _    _
-              @grv  @dft  @qwe  @gam  @bas  _     _     _     _     _     _     _     _    _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _                   @rSspc               @rAbspc  _
-            )
-
-            (deflayer arrows-symbols-bak
-              _     _      _      _      _      _      _      _      _      _      _       _       _      _
-              @`    f1     f2     f3     f4     f5     f6     f7     f8     f9     f10     f11     f12    _
-              _     @|     @/     @'lp   @'rp   _      _      pgdn   pgup   _      _       _       _
-              _     @at    @<     @[     @]     @>     left   down   up     rght   _       _       _
-              _     _      @\     _      @{     @}     @~     _      _      home   end     _       _
-              _     _     _                     bspc                           _     _
-            )
-
-            (deflayer arrows-symbols
-              _     _      _      _      _      _      _      _      _      _      _       _       _      _
-              @`    @`     @'lp   @'rp   ;      _      _      _      _      _      _       _       _      _
-              _     @{     @[   @]   @}     _      _      pgdn   pgup   _      _       _       _
-              @^     @at    @=     @_     @$     @*     left   down   up     rght   _       _       _
-              _     _      @|     @\     @{     @}     @~     _      _      home   end     _       _
-              _     _     _                     bspc                           _     _
-            )
-
-            (deflayer media-controls
-              _     _      _      _      _      _      _      _      _      _      _     _     _     _
-              _     mute   voldwn volu   _      brdwn  brup   pp     prev   next   prnt  _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _                     bspc                            _     _
-            )
-
-            (deflayer numbers
-              _     _     _     _     _     _     _     _     _     _     _     _     _    _
-              _     _     _     _     _     _     _     _     _     _     _     _     _    _
-              _     _     _     _     _     _     @%    @'1   @'2   @'3   @:    _     _
-              _     _     _     _     _     _     @+    @'4   @'5   @'6   @-    _     _
-              _     _     _     _     _     _     @*    @'7   @'8   @'9   @/    _     _
-              _     _     _                   @'0                   _     _
-            )
-
-            (defalias
-              'q   m
-              'e   f
-              'r   l
-              't   j
-              'u   s
-              'i   d
-              'o   r
-              'p   e
-              'a   a
-              's   k
-              'd   i
-              'f   /
-              'g   ,
-              'h   .
-              'j   p
-              'k   b
-              'l   o
-              ';   S-g
-              '    n
-              'x   c
-              'c   h
-              'v   u
-              'b   q
-              'n   ;
-              'm   '
-              ',   g
-              '.   v
-              '/   9
-            )
-
-            (deflayer qwerty
-              esc     f1    f2    f3     f4     f5     f6    f7    f8     f9     f10    f11   f12  del
-              @grv    @'1   @'2   @'3    @'4    @'5    @'6   @'7   @'8    @'9    @'0    -     =    _
-              tab     @'q   'w    @'e    @'r    @'t    'y    @'u   @'i    @'o    @'p    @[    @]
-              caps    @'a   @'s   @'d    @'f    @'g    @'h   @'j   @'k    @'l    @';    @'    ret
-              lsft    '<    'z    @'x    @'c    @'v    @'b   @'n   @'m    @',    @'.    @'/   rsft
-              lctl lmet lalt                     spc                @rAbspc rctl
-            )
-
-            (deflayer gaming
-              esc     f1    f2    f3     f4     f5     f6    f7    f8     f9     f10    f11   f12  del
-              @grv    @'1   @'2   @'3    @'4    @'5    @'6   @'7   @'8    @'9    @'0    -     =    _
-              tab     @'q   up    @'e    @'r    @'t    'y    @'u   @'i    @'o    @'p    @[    @]
-              caps    left  down  rght   @'f    @'g    @'h   @'j   @'k    @'l    @';    @'    ret
-              lsft    '<    'z    @'x    @'c    @'v    @'b   @'n   @'m    @',    @'.    @'/   rsft
-              lctl lmet lalt                     spc                @rAbspc rctl
-            )
-
-            (deflayer basic
-              _     _     _     _     _     _     _     _     _     _     _     _     _     _
-              @grv  _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _     _     _     _     _     _     _     _     _     _     _
-              _     _     _                       _                 _     _
-            )
+            ;; Application launcher shortcut for navigation layer ([Space]+[P])
+            (defalias run XX)
           '';
         };
     };

--- a/modules/nixos/system/kanata/deflayer/base.kbd
+++ b/modules/nixos/system/kanata/deflayer/base.kbd
@@ -1,0 +1,11 @@
+;; Base layer: standard keyboard behavior
+
+(deflayer base
+  _    _    _    _    _    _    _    _    _    _    _
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  z    x    c    v    b    <    n    m    ,    .    /
+            _              _              _
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/base_lt.kbd
+++ b/modules/nixos/system/kanata/deflayer/base_lt.kbd
@@ -1,0 +1,23 @@
+;; Base layer: the 3 main thumb keys become mod/taps
+
+(deflayer base
+  _    _    _    _    _    _    _    _    _    _    _
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  z    x    c    v    b    <    n    m    ,    .    /
+            @alt          @nav            @sym
+)
+
+;; Timing variables are defined in `kanata.kbd` file.
+
+(defalias
+  ;; Main mod-tap: Nav layer when held, Space when tapped.
+  nav (tap-hold $tap_timeout $long_hold_timeout spc (layer-while-held navigation))
+
+  ;; Space-cadet thumb keys: Alt/BackSpace, AltGr/Enter.
+  ;; Acts as a modifier by default, or as BackSpace/Enter when tapped separately.
+  alt (tap-hold-press $tap_timeout $hold_timeout bspc lalt)
+  sym (tap-hold-press $tap_timeout $hold_timeout ret (layer-while-held symbols))
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/base_lt_hrm.kbd
+++ b/modules/nixos/system/kanata/deflayer/base_lt_hrm.kbd
@@ -1,0 +1,31 @@
+;; Base layer: layer-taps under the thumbs + home-row mods on SDF and JKL
+
+(deflayer base
+  _    _    _    _    _    _    _    _    _    _    _
+  q    w    e    r    t         y    u    i    o    p
+  a    @ss  @dd  @ff  g         h    @jj  @kk  @ll  ;
+  z    x    c    v    b    <    n    m    ,    .    /
+            @sft          @nav            @sym
+)
+
+;; Timing variables are defined in `kanata.kbd` file.
+
+(defalias
+  ;; Main mod-tap: Nav layer when held, Space when tapped.
+  nav (tap-hold $tap_timeout $long_hold_timeout spc (layer-while-held navigation))
+
+  ;; Space-cadet thumb keys: Shift/BackSpace, AltGr/Enter.
+  ;; Acts as a modifier by default, or as BackSpace/Enter when tapped separately.
+  sft (tap-hold-press $tap_timeout $hold_timeout bspc lsft)
+  sym (tap-hold-press $tap_timeout $hold_timeout ret (layer-while-held symbols))
+
+  ;; Home-row mods
+  ss (tap-hold $tap_timeout $long_hold_timeout s lmet)
+  dd (tap-hold $tap_timeout $long_hold_timeout d lctl)
+  ff (tap-hold $tap_timeout $long_hold_timeout f lalt)
+  jj (tap-hold $tap_timeout $long_hold_timeout j lalt)
+  kk (tap-hold $tap_timeout $long_hold_timeout k rctl)
+  ll (tap-hold $tap_timeout $long_hold_timeout l rmet)
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/navigation.kbd
+++ b/modules/nixos/system/kanata/deflayer/navigation.kbd
@@ -1,0 +1,17 @@
+;; Num-Navigation layer:
+;;  - should inherit from NumPad
+;;  - left: one-handed shortcuts (Cmd/Ctrl-AZXCV) + Tab/S-Tab
+;;  - top: Super-num (i3/sway) or Alt-num (browser)
+
+;; The `lrld` action stands for "live reload". This will re-parse everything
+;; except for linux-dev, i.e. you cannot live reload and switch keyboard devices.
+
+(deflayer navigation
+  M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
+  tab  home up   end  pgup      @/   @7   @8   @9   @run
+  @all lft  down rght pgdn      @-   @4   @5   @6   @0
+  @ndo @cut @cpy @pst S-tab _   @,   @1   @2   @3   @.
+            del             _             esc
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/navigation_vim.kbd
+++ b/modules/nixos/system/kanata/deflayer/navigation_vim.kbd
@@ -1,0 +1,48 @@
+;; Vim-Navigation layer:
+;;  - right: Vim-like arrows on HJKL, home/end page up/down, mouse scroll
+;;  - left: one-hand shortcuts (Cmd/Ctrl-WASZXCV), Tab/Shift-Tab, prev/next
+;;  - top: Super-num (i3/sway) or Alt-num (browser), zoom in/out
+
+;; The `lrld` action stands for "live reload". This will re-parse everything
+;; except for linux-dev, i.e. you cannot live reload and switch keyboard devices.
+
+(deflayer navigation
+  M-1  M-2  M-3  M-4  M-5  lrld M-6  M-7  M-8  M-9  M-0
+  @pad @cls bck  fwd  XX        home pgdn pgup end  @run
+  @all @sav S-tab tab XX        lft  down up   rght @fun
+  @ndo @cut @cpy @pst XX    _   @mwl @mwd @mwu @mwr XX
+            del             _             esc
+)
+
+;; NumPad
+(deflayer numpad
+  _    _    _    _    _     _   _    _    _    _    _
+  XX   home up   end  pgup      @/   @7   @8   @9   XX
+  XX   lft  down rght pgdn      @-   @4   @5   @6   @0
+  XX   XX   XX   XX   XX    _   @,   @1   @2   @3   @.
+            @std           @nbs           @std
+)
+
+;; function keys
+(deflayer funpad
+  XX   XX   XX   XX   XX   XX   XX   XX   XX   XX   XX
+  f1   f2   f3   f4   XX        XX   XX   XX   XX   XX
+  f5   f6   f7   f8   XX        XX   lctl lalt lmet _
+  f9   f10  f11  f12  XX   XX   XX   XX   XX   XX   XX
+            _               _             _
+)
+
+(defalias
+  std (layer-switch base)
+  pad (layer-switch numpad)
+
+  fun (layer-while-held funpad)
+
+  ;; Mouse wheel emulation
+  mwu (mwheel-up    50 120)
+  mwd (mwheel-down  50 120)
+  mwl (mwheel-left  50 120)
+  mwr (mwheel-right 50 120)
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/symbols_lafayette.kbd
+++ b/modules/nixos/system/kanata/deflayer/symbols_lafayette.kbd
@@ -1,0 +1,14 @@
+;; Symbol layer: Lafayette/Ergo‑L AltGr programmation layer for the masses!
+
+(deflayer symbols
+  AG-1 AG-2 AG-3 AG-4 AG-5 XX   AG-6 AG-7 AG-8 AG-9 AG-0
+  @^   @<   @>   @$   @%        @@   @&   @*   @'   @`
+  @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''
+  @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
+            _             spc             _
+)
+
+;; Note: this requires kanata 0.5+ to work properly.
+;; kanata 0.4 does not release Shift soon enough for this layer to work.
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/symbols_lafayette_num.kbd
+++ b/modules/nixos/system/kanata/deflayer/symbols_lafayette_num.kbd
@@ -1,0 +1,26 @@
+;; Symbol layer: Lafayette/Ergo‑L AltGr programmation layer
+;; but enables a NumRow.
+
+(deflayer symbols
+  AG-1 AG-2 AG-3 AG-4 AG-5 XX   AG-6 AG-7 AG-8 AG-9 AG-0
+  @^   @<   @>   @$   @%        @@   @&   @*   @'   @`
+  @{   @pl  @pr  @}   @=        @\   @+   @-   @/   @''
+  @~   @[   @]   @_   @#   XX   @|   @!   @;   @:   @?
+            @num          spc             _
+)
+
+;; Numrow layer
+
+(deflayer numrow
+  _    _    _    _    _     _   _    _    _    _    _
+  @s1  @s2  @s3  @s4  @s5       @s6  @s7  @s8  @s9  @s0
+  @1   @2   @3   @4   @5        @6   @7   @8   @9   @0
+  @dk1 @dk2 @dk3 @dk4 @dk5  _   XX   @-   @,   @.   @/
+            _              @nbs           @sym
+)
+
+(defalias
+  num (layer-toggle numrow)
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/symbols_noop.kbd
+++ b/modules/nixos/system/kanata/deflayer/symbols_noop.kbd
@@ -1,0 +1,14 @@
+;; Symbol layer: same as AltGr.
+;; Concretely this does nothing, just let AltGr as-is for keyboard layouts
+;; depending heavily on AltGr, like Bépo or simply Lafayette layouts like
+;; Ergo‑L, which already have that layer baked in.
+
+(deflayer symbols
+  AG-1 AG-2 AG-3 AG-4 AG-5  XX  AG-6 AG-7 AG-8 AG-9 AG-0
+  AG-q AG-w AG-e AG-r AG-t      AG-y AG-u AG-i AG-o AG-p
+  AG-a AG-s AG-d AG-f AG-g      AG-h AG-j AG-k AG-l AG-;
+  AG-z AG-x AG-c AG-v AG-b AG-< AG-n AG-m AG-, AG-. AG-/
+            _             AG-spc          _
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/deflayer/symbols_noop_num.kbd
+++ b/modules/nixos/system/kanata/deflayer/symbols_noop_num.kbd
@@ -1,0 +1,29 @@
+;; Symbol layer: same as AltGr but enables a NumRow.
+;; Concretely this does nothing, just let AltGr as-is for keyboard layouts
+;; depending heavily on AltGr, like Bépo or simply Lafayette layouts like
+;; Ergo‑L, which already have that layer baked in.
+;; Except it adds an NumRow layer.
+
+(deflayer symbols
+  AG-1 AG-2 AG-3 AG-4 AG-5  XX  AG-6 AG-7 AG-8 AG-9 AG-0
+  AG-q AG-w AG-e AG-r AG-t      AG-y AG-u AG-i AG-o AG-p
+  AG-a AG-s AG-d AG-f AG-g      AG-h AG-j AG-k AG-l AG-;
+  AG-z AG-x AG-c AG-v AG-b AG-< AG-n AG-m AG-, AG-. AG-/
+            @num          AG-spc          _
+)
+
+;; Numrow layer
+
+(deflayer numrow
+  _    _    _    _    _     _   _    _    _    _    _
+  @s1  @s2  @s3  @s4  @s5       @s6  @s7  @s8  @s9  @s0
+  @1   @2   @3   @4   @5        @6   @7   @8   @9   @0
+  @dk1 @dk2 @dk3 @dk4 @dk5  _   XX   @-   @,   @.   @/
+            _              @nbs           @sym
+)
+
+(defalias
+  num (layer-toggle numrow)
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/mac.kbd
+++ b/modules/nixos/system/kanata/defsrc/mac.kbd
@@ -1,0 +1,11 @@
+;; `defsrc` defines the keys that will be intercepted by kanata.
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  z    x    c    v    b    <    n    m    ,    .    /
+            lmet          spc             rmet
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/mac_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/mac_anglemod.kbd
@@ -1,0 +1,11 @@
+;; angle-mod: the ISO key (a.k.a. LSGT or 102 key) becomes Z
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  <    z    x    c    v    b    n    m    ,    .    /
+            lmet          spc             rmet
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/mac_ansi_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/mac_ansi_anglemod.kbd
@@ -1,0 +1,11 @@
+;; ansi-angle-mod: left shift becomes Z
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  lsft z    x    c    v    b    n    m    ,    .    /
+            lmet          spc             rmet
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/mac_ansi_wide_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/mac_ansi_wide_anglemod.kbd
@@ -1,0 +1,14 @@
+;; wide-angle-mod:
+;; - left shift becomes Z
+;; - the right hand is moved one key to the right
+
+
+(defsrc
+  1    2    3    4    5  bspc   7    8    9    0    -
+  q    w    e    r    t         u    i    o    p    [
+  a    s    d    f    g         j    k    l    ;    '
+  lsft z    x    c    v    b    m    ,    .    /    rsft
+            lmet          spc             rmet
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/mac_wide_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/mac_wide_anglemod.kbd
@@ -1,0 +1,14 @@
+;; wide-angle-mod:
+;; - the ISO key (a.k.a. LSGT or 102 key) becomes Z
+;; - the right hand is moved one key to the right
+
+
+(defsrc
+  1    2    3    4    5  bspc   7    8    9    0    -
+  q    w    e    r    t         u    i    o    p    [
+  a    s    d    f    g         j    k    l    ;    '
+  <    z    x    c    v    b    m    ,    .    /    rsft
+            lmet          spc             rmet
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/pc.kbd
+++ b/modules/nixos/system/kanata/defsrc/pc.kbd
@@ -1,0 +1,11 @@
+;; `defsrc` defines the keys that will be intercepted by kanata.
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  z    x    c    v    b    <    n    m    ,    .    /
+            lalt          spc             ralt
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/pc_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/pc_anglemod.kbd
@@ -1,0 +1,11 @@
+;; angle-mod: the ISO key (a.k.a. LSGT or 102 key) becomes Z
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  <    z    x    c    v    b    n    m    ,    .    /
+            lalt          spc             ralt
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/pc_ansi_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/pc_ansi_anglemod.kbd
@@ -1,0 +1,11 @@
+;; ansi-angle-mod: left shift becomes Z
+
+(defsrc
+  1    2    3    4    5  bspc   6    7    8    9    0
+  q    w    e    r    t         y    u    i    o    p
+  a    s    d    f    g         h    j    k    l    ;
+  lsft z    x    c    v    b    n    m    ,    .    /
+            lalt          spc             ralt
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/pc_ansi_wide_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/pc_ansi_wide_anglemod.kbd
@@ -1,0 +1,13 @@
+;; wide-angle-mod:
+;; - left shift becomes Z
+;; - the right hand is moved one key to the right
+
+(defsrc
+  1    2    3    4    5  bspc   7    8    9    0    -
+  q    w    e    r    t         u    i    o    p    [
+  a    s    d    f    g         j    k    l    ;    '
+  lsft z    x    c    v    b    m    ,    .    /    rsft
+            lalt          spc             ralt
+)
+
+;; vim: set ft=lisp

--- a/modules/nixos/system/kanata/defsrc/pc_wide_anglemod.kbd
+++ b/modules/nixos/system/kanata/defsrc/pc_wide_anglemod.kbd
@@ -1,0 +1,13 @@
+;; wide-angle-mod:
+;; - the ISO key (a.k.a. LSGT or 102 key) becomes Z
+;; - the right hand is moved one key to the right
+
+(defsrc
+  1    2    3    4    5  bspc   7    8    9    0    -
+  q    w    e    r    t         u    i    o    p    [
+  a    s    d    f    g         j    k    l    ;    '
+  <    z    x    c    v    b    m    ,    .    /    rsft
+            lalt          spc             ralt
+)
+
+;; vim: set ft=lisp

--- a/systems/x86_64-linux/daftop/default.nix
+++ b/systems/x86_64-linux/daftop/default.nix
@@ -52,10 +52,7 @@ in
     };
 
     system = {
-      kanata = {
-        enable = true;
-        chordTimeout = 25;
-      };
+      kanata = enabled;
 
       networking = {
         enable = true;


### PR DESCRIPTION
## Summary

Replaces the hand-written bépo kanata config in [modules/nixos/system/kanata/default.nix](../blob/kanata/switch-to-arsenik-ergol/modules/nixos/system/kanata/default.nix) with [arsenik](https://github.com/OneDeadKey/arsenik), composing upstream component files at build time via `builtins.readFile`.

## Why

Switching the system keyboard layout from bépo to Ergo‑L. Rather than maintain a hand-rolled kanata config, this adopts arsenik's modular components — its Symbols layer maps directly onto Ergo‑L's Lafayette AltGr layer, so the system layout does the symbol work and kanata just adds layer-taps, home-row mods, and a navigation layer on top.

## Chosen variants

| Slot | File | Notes |
| --- | --- | --- |
| defsrc | `defsrc/pc_anglemod.kbd` | PC anglemod (ISO key, ZXCVB shifted left) |
| base | `deflayer/base_lt_hrm.kbd` | layer-taps under thumbs + home-row mods on SDF/JKL |
| symbols | `deflayer/symbols_noop_num.kbd` | passthrough AltGr (Ergo‑L provides Lafayette) + NumRow sublayer |
| navigation | `deflayer/navigation_vim.kbd` | HJKL arrows, NumPad on `[Space]+[Q]`, mouse-wheel emulation |
| layout aliases | `defalias/ergol_pc.kbd` | Ergo‑L PC bindings |

## Notable behavior changes

- Keyboard label renamed `bepo` → `ergol`, so the systemd unit becomes `kanata-ergol.service`.
- Dropped the `chordTimeout` option (arsenik does not use chords).
- Added `longHoldTimeout` option. Defaults match arsenik upstream: 200 / 200 / 300 ms.
- App-launcher shortcut on `[Space]+[P]` is currently `(defalias run XX)` (no-op) — set this to e.g. `M-p` when ready.

## Test plan

- [ ] `nixos-rebuild switch` succeeds on `daftop`
- [ ] `systemctl status kanata-ergol.service` shows active
- [ ] Base typing, home-row mods (s/d/f/j/k/l), and thumb keys (sft/nav/sym) all behave as expected
- [ ] HJKL navigation works under `[Space]`-hold
- [ ] AltGr symbols still match Ergo‑L (passthrough)
- [ ] NumRow sublayer reachable from symbols layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)